### PR TITLE
Fix gitmodules for recursive clone to always succeed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,10 +15,10 @@
 	url = https://github.com/cloudfoundry-incubator/cf-routing-release
 [submodule "images/bosh/src/github.com/sclevine/packer-bosh"]
 	path = images/bosh/src/github.com/sclevine/packer-bosh
-	url = git@github.com:sclevine/packer-bosh
+	url = https://github.com/sclevine/packer-bosh
 [submodule "images/bosh/src/github.com/sclevine/bosh-provisioner"]
 	path = images/bosh/src/github.com/sclevine/bosh-provisioner
-	url = git@github.com:sclevine/bosh-provisioner
+	url = https://github.com/sclevine/bosh-provisioner
 [submodule "images/releases/cf-redis-release"]
 	path = images/releases/cf-redis-release
 	url = https://github.com/pivotal-cf/cf-redis-release


### PR DESCRIPTION
If I run a git clone recursive with valid github ssh keys loaded, even though the submodules are all OSS, the clone fails because of limited access rights to the git@ submodules. The https url will allow the recursive clone to always succeed.